### PR TITLE
[Autofix][warning] Alert #59: Poorly documented large function

### DIFF
--- a/XEngine_Source/XEngine_ModuleConfigure/ModuleConfigure_Json/ModuleConfigure_Json.cpp
+++ b/XEngine_Source/XEngine_ModuleConfigure/ModuleConfigure_Json/ModuleConfigure_Json.cpp
@@ -42,18 +42,23 @@ CModuleConfigure_Json::~CModuleConfigure_Json()
 *********************************************************************/
 bool CModuleConfigure_Json::ModuleConfigure_Json_File(LPCXSTR lpszConfigFile, XENGINE_SERVICECONFIG* pSt_ServerConfig)
 {
+	// 约定：每次进入函数先清除错误状态，后续任一步失败都设置错误码并返回 false。
 	Config_IsErrorOccur = false;
 
+	// 第一步：校验输入参数，配置文件路径和输出结构体都不能为空。
 	if ((NULL == lpszConfigFile) || (NULL == pSt_ServerConfig))
 	{
 		Config_IsErrorOccur = true;
 		Config_dwErrorCode = ERROR_MODULE_CONFIGURE_JSON_PARAMENT;
 		return false;
 	}
+
+	// 第二步：准备 JSON 解析器对象与错误信息缓冲。
 	Json::Value st_JsonRoot;
 	JSONCPP_STRING st_JsonError;
 	Json::CharReaderBuilder st_JsonBuilder;
-	//读取配置文件所有内容到缓冲区
+
+	// 第三步：读取配置文件内容到固定缓冲区（当前实现最多读取 8192 字节）。
 	FILE* pSt_File = _xtfopen(lpszConfigFile, _X("rb"));
 	if (NULL == pSt_File)
 	{
@@ -64,7 +69,8 @@ bool CModuleConfigure_Json::ModuleConfigure_Json_File(LPCXSTR lpszConfigFile, XE
 	XCHAR tszMsgBuffer[8192];
 	int nRet = fread(tszMsgBuffer, 1, sizeof(tszMsgBuffer), pSt_File);
 	fclose(pSt_File);
-	//开始解析配置文件
+
+	// 第四步：解析 JSON 文本。解析失败时返回统一的解析错误码。
 	std::unique_ptr<Json::CharReader> const pSt_JsonReader(st_JsonBuilder.newCharReader());
 	if (!pSt_JsonReader->parse(tszMsgBuffer, tszMsgBuffer + nRet, &st_JsonRoot, &st_JsonError))
 	{
@@ -72,6 +78,8 @@ bool CModuleConfigure_Json::ModuleConfigure_Json_File(LPCXSTR lpszConfigFile, XE
 		Config_dwErrorCode = ERROR_MODULE_CONFIGURE_JSON_PARSE;
 		return false;
 	}
+
+	// 第五步：将 JSON 字段映射到服务配置结构体，供调用方后续使用。
 	_tcsxcpy(pSt_ServerConfig->tszIPAddr, st_JsonRoot["tszIPAddr"].asCString());
 	pSt_ServerConfig->bDeamon = st_JsonRoot["bDeamon"].asBool();
 	pSt_ServerConfig->nHttpPort = st_JsonRoot["nHttpPort"].asInt();


### PR DESCRIPTION
## 🤖 Copilot Autofix 自动修复报告

---

### 📋 基本信息

| 字段 | 内容 |
|------|------|
| **Alert ID** | [#59](https://github.com/libxengine/XEngine_ProxyServer/security/code-scanning/59) |
| **安全级别** | warning |
| **规则名称** | Poorly documented large function |
| **问题文件** | `XEngine_Source/XEngine_ModuleConfigure/ModuleConfigure_Json/ModuleConfigure_Json.cpp` 第 43 行 |
| **CWE 分类** |  |
| **规则标签** | documentation, maintainability, non-attributable, statistical |

---

### 🔍 问题说明

# Poorly documented large function
This rule finds large functions that have too few comment lines. Documentation becomes more important as a function becomes more complex, and a lack of documentation makes it harder to maintain.


## Recommendation
Add comments to document the purpose of the function. Large, complex functions in particular require detailed documentation, not only because they are harder to understand, but the process of documentation may reveal that the function could be split into smaller, more cohesive functions.


## References
* [C++ Programming, Coding style conventions](http://en.wikibooks.org/wiki/C%2B%2B_Programming/Programming_Languages/C%2B%2B/Code/Style_Conventions#Comments)
* [Wikipedia: Need for comments](http://en.wikipedia.org/wiki/Comment_%28computer_progr

---

### 🤖 AI 修复思路

To fix this without changing behavior, add meaningful inline documentation inside `ModuleConfigure_Json_File` that explains each major processing phase and key assumptions, rather than changing logic. Keep the existing function and code paths intact; just improve maintainability by documenting: parameter validation and error contract, file I/O limits (fixed buffer read), JSON parse stage, and configuration field extraction.

Best concrete fix in `XEngine_Source/XEngine_ModuleConfigure/ModuleConfigure_Json/ModuleConfigure_Json.cpp`:
- Update comments around `ModuleConfigure_Json_File` (line 43 onward).
- Add a short function-level note before the body describing workflow and error signaling (`Config_IsErrorOccur` / `Config_dwErrorCode`).
- Add block/line comments before each major section:
  1) input validation,
  2) JSON parser setup,
  3) file open/read/close behavior,
  4) parsing and parse-failure behavior,
  5) config field mapping and return behavior.
- Do not alter any variable names, control flow, or assignments.

No new imports, methods, or dependencies are needed.

---

### ✅ Review 检查清单

- [ ] 理解了漏洞的成因和影响范围
- [ ] 确认 AI 修复逻辑正确，没有遗漏边界情况
- [ ] 确认修复没有改变原有业务逻辑
- [ ] 确认没有引入新的安全问题
- [ ] CI / 单元测试全部通过
- [ ] 如有必要，已补充对应的测试用例

---

> 此 PR 由 GitHub Copilot Autofix 自动生成，请仔细审核后再 merge。